### PR TITLE
Updated AboutUs page: Format typo and Student D

### DIFF
--- a/src/main/webapp/aboutus.html
+++ b/src/main/webapp/aboutus.html
@@ -21,7 +21,7 @@ limitations under the License.
     <title>About Us</title>
     <link rel="stylesheet" href="/css/main.css">
   </head>
-  </head>
+  <body>
     <nav>
       <ul id="navigation">
         <li><a href="/">Home</a></li>

--- a/src/main/webapp/aboutus.html
+++ b/src/main/webapp/aboutus.html
@@ -47,11 +47,32 @@ limitations under the License.
       <li>Aspirational Hobby: </li>
       <li>Ask me About: </li>
     </ul>
-    <h2>Teammate D Name (delete if you team only has 3 students) </h2>
+    <h2>Michelle S Lee</h2>
     <ul>
-      <li>Summer Feelz: </li>
-      <li>Aspirational Hobby: </li>
-      <li>Ask me About: </li>
+      <li> Summer Feelz: Excited | Nervous | Hopeful </li>
+      <li>Aspirational Hobby: Too many things and too vague haha.
+
+        1) Improve expected Return models for governance decisions that factor in more than obvious monetary returns (ex: social utility in the form of yes economic return but also living standards, future developmental opportunities, etc... ). Kinda like what William D. Nordhaus and Paul M. Romer have done by integrating climate change and the multifaceted effects of tech change.
+
+        I don't have enugh technical or socioeconomic knowledge for this but probability based decision making is always an interesting thing for me! And I've been interested in complex networks recently.
+
+        2) Better STEM education models? Around tech ed and personalized education specifically.
+
+        Such a buzzword, definitely don't know enough about it... But I'm sure with recent improvements in cognitive science, stronger predictive/ computational power, crazy amounts of data in an increasingly connected world this will be a space with a lot of impact!!
+
+        Just interested in the ties between communication design/ learning psychology/ datascience here and how that can be a force for equalization in education. Like what Khan Academy has done with skill based education, increased transparency in current abiilty/ curriculum, gamification, and personalized recommendations are super interesting to me and I think all of this will only develop further.
+
+        3) Dance/ piano? They've always been fun and mildly meditative to me C:
+
+      </li>
+      <li>Ask me About:
+
+        I love listening to people debate about the social networks of inequalities, whether thats minorities in tech, gentrification, immigration, etc. The multiple aspects of the problem, the feedback loops that they create (which make the problem self reinforcing and multifacted), the purposes/ perspectives of the groups of players in the network that create networks of mismatched local vs globally optimum actions, etc! I don't have answers but it's always fun to explore the topic.
+
+        I'm also super interested in innovation/ entreprenuership (and education!) and the role of individual entreprenuers in improving the living standards of their community and how to design "products"/ build communities that do that!
+
+        If you guys have any organisations/ products that kinda work on these kinds of problems/ focuses on social network based solutions I'm always interested!!
+      </li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
1) fixed typo in /aboutus.html where there is an extra closed head tag, and missing an open body tag.
2) Updated Student D section of the /aboutus.html page with my info.